### PR TITLE
Treat assets and icons as external resource and link them directly to @wikia/react-common/x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ typings/
 # build
 /dist/
 
+package-lock.json
+
 # TODO remove this list
 /assets
 /components

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "classnames": "^2.2.6",
     "date-fns": "^1.29.0",
     "design-system": "git://github.com/Wikia/design-system.git#19.2.0",
+    "immutable": "^4.0.0-rc.12",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
-    "react-select": "^2.1.1",
     "react-redux": "^5.0.7",
-    "immutable": "^4.0.0-rc.12"
+    "react-select": "^2.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",
@@ -90,6 +90,7 @@
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-postcss": "^2.0.0",
+    "rollup-plugin-postprocess": "^1.0.2",
     "rollup-plugin-react-svg": "^2.1.0",
     "rollup-plugin-sass": "^1.0.0",
     "rollup-plugin-string": "^2.0.2",

--- a/source/components/Select/DropdownIndicator.js
+++ b/source/components/Select/DropdownIndicator.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { components } from 'react-select';
 
 // eslint-disable-next-line no-restricted-imports
@@ -24,4 +25,12 @@ export const DefaultDropdownIndicator = (props) => {
             <IconDropdown className={className} />
         </components.DropdownIndicator>
     );
+};
+
+DefaultDropdownIndicator.propTypes = {
+    isFocused: PropTypes.bool,
+};
+
+DefaultDropdownIndicator.defaultProps = {
+    isFocused: false,
 };

--- a/source/components/Select/IndicatorsContainer.js
+++ b/source/components/Select/IndicatorsContainer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { components } from 'react-select';
 
 const IndicatorsContainer = (props) => {
@@ -13,6 +14,13 @@ const IndicatorsContainer = (props) => {
             {indicatorSeparator}
         </components.IndicatorsContainer>
     );
+};
+
+IndicatorsContainer.propTypes = {
+    // eslint-disable-next-line
+    children: PropTypes.any,
+    // eslint-disable-next-line
+    selectProps: PropTypes.any,
 };
 
 export default IndicatorsContainer;

--- a/source/components/Select/__snapshots__/index.spec.js.snap
+++ b/source/components/Select/__snapshots__/index.spec.js.snap
@@ -559,6 +559,7 @@ exports[`Select renders correctly 6`] = `
         </div>
         <input
           className="css-14uuagi"
+          disabled={false}
           id="fandom-select-input"
           onBlur={[Function]}
           onChange={[Function]}

--- a/source/components/SimpleLocalNavigation/index.js
+++ b/source/components/SimpleLocalNavigation/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+// eslint-disable-next-line no-restricted-imports
 import FandomContentWell from '../FandomContentWell';
 
 import './styles.scss';

--- a/source/components/index.js
+++ b/source/components/index.js
@@ -10,7 +10,7 @@ export { default as ButtonGroup } from './ButtonGroup';
 export { default as Input } from './Input';
 export { default as Fieldset } from './Fieldset';
 export { default as Spinner } from './Spinner';
-export { default as Dropdown } from './Spinner';
+export { default as Dropdown } from './Dropdown';
 export { default as FloatingButton } from './FloatingButton';
 export { default as FloatingButtonGroup } from './FloatingButtonGroup';
 // Design System UI

--- a/source/systems/BannerNotifications/StoreModel.js
+++ b/source/systems/BannerNotifications/StoreModel.js
@@ -52,6 +52,7 @@ class BannerNotificationsStoreModel extends Model(schema, 'BannerNotificationsSt
         const notifications = this.get(BANNER_NOTIFICATIONS_MODEL_KEYS.notifications, List());
 
         // when it's empty, sometimes `toJS` returns Object instead of Array :(
+        /* istanbul ignore next */
         return notifications.size ? notifications : List();
     }
 

--- a/source/systems/BannerNotifications/StoreModel.js
+++ b/source/systems/BannerNotifications/StoreModel.js
@@ -49,7 +49,10 @@ class BannerNotificationsStoreModel extends Model(schema, 'BannerNotificationsSt
     }
 
     getNotifications() {
-        return this.get(BANNER_NOTIFICATIONS_MODEL_KEYS.notifications);
+        const notifications = this.get(BANNER_NOTIFICATIONS_MODEL_KEYS.notifications, List());
+
+        // when it's empty, sometimes `toJS` returns Object instead of Array :(
+        return notifications.size ? notifications : List();
     }
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -10673,6 +10673,13 @@ rollup-plugin-postcss@^2.0.0:
     rollup-pluginutils "^2.0.1"
     style-inject "^0.3.0"
 
+rollup-plugin-postprocess@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-postprocess/-/rollup-plugin-postprocess-1.0.2.tgz#673d31ccbfb121dfa8c836d2f35b8c6f508a8b5f"
+  integrity sha512-teKF5sVgjoQPRF9IV4wTED0Tx6kuoyz4rxkiSG9NweBC28fwXy+sZ0HLDw9GwCwck///08hFGi0RY4jlSdoZTA==
+  dependencies:
+    magic-string "^0.22.4"
+
 rollup-plugin-react-svg@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-react-svg/-/rollup-plugin-react-svg-2.1.0.tgz#bd9612f10d2e181277a7d9d12bdfd57eade91ab6"


### PR DESCRIPTION
Add some minor cleanup in the meantime.

How the fix works: Because SVGs (icons/assets) were previously INCLUDED in the output React components - thus the asset included both in A and in B resulted with the same code being there twice.

This change effectively replaces with directly referencing the assets.