### PR TITLE
IW-1859 | Fix discussions moderator badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikia/react-common",
-  "version": "7.0.3",
+  "version": "7.0.3-badges2",
   "description": "Wikia's reusable React parts",
   "repository": "git@github.com:Wikia/react-common.git",
   "license": "UNLICENSED",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikia/react-common",
-  "version": "7.0.3-badges2",
+  "version": "7.0.3",
   "description": "Wikia's reusable React parts",
   "repository": "git@github.com:Wikia/react-common.git",
   "license": "UNLICENSED",

--- a/source/components/Avatar/Badge.js
+++ b/source/components/Avatar/Badge.js
@@ -19,7 +19,7 @@ const Badge = ({ badge, className }) => {
             icon: <AvatarBadgeContentModerator />,
             title: 'Content Moderator',
         },
-        'discussion-moderator': {
+        'threadmoderator': {
             icon: <AvatarBadgeDiscussionModerator />,
             title: 'Discussions Moderator',
         },

--- a/source/components/Avatar/Badge.js
+++ b/source/components/Avatar/Badge.js
@@ -11,7 +11,7 @@ import AvatarBadgeVstf from '../../assets/AvatarBadgeVstf';
 
 const Badge = ({ badge, className }) => {
     const badgeIcons = {
-        admin: {
+        sysop: {
             icon: <AvatarBadgeAdmin />,
             title: 'Community Admin',
         },

--- a/source/components/Avatar/Badge.js
+++ b/source/components/Avatar/Badge.js
@@ -19,7 +19,7 @@ const Badge = ({ badge, className }) => {
             icon: <AvatarBadgeContentModerator />,
             title: 'Content Moderator',
         },
-        'threadmoderator': {
+        threadmoderator: {
             icon: <AvatarBadgeDiscussionModerator />,
             title: 'Discussions Moderator',
         },

--- a/source/components/Avatar/__snapshots__/index.spec.js.snap
+++ b/source/components/Avatar/__snapshots__/index.spec.js.snap
@@ -1,6 +1,321 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Avatar renders when incorrect badgePermission is set 1`] = `
+exports[`Avatar Avatar renders for "content-moderator" badge permission 1`] = `
+<Avatar
+  alt="User avatar"
+  badge="content-moderator"
+>
+  <div
+    className="wds-avatar"
+  >
+    <AvatarImage
+      alt="User avatar"
+    >
+      <_default
+        className="wds-avatar__image"
+        title="wds-avatar__image"
+      >
+        <_default
+          className="wds-avatar__image"
+          title="wds-avatar__image"
+        >
+          <div
+            className="wds-avatar__image"
+            title="wds-avatar__image"
+          />
+        </_default>
+      </_default>
+    </AvatarImage>
+    <Badge
+      badge="content-moderator"
+      className=""
+    >
+      <span
+        className="wds-avatar__badge "
+        title="Content Moderator"
+      >
+        <_default>
+          <_default>
+            <div />
+          </_default>
+        </_default>
+      </span>
+    </Badge>
+  </div>
+</Avatar>
+`;
+
+exports[`Avatar Avatar renders for "global-discussions-moderator" badge permission 1`] = `
+<Avatar
+  alt="User avatar"
+  badge="global-discussions-moderator"
+>
+  <div
+    className="wds-avatar"
+  >
+    <AvatarImage
+      alt="User avatar"
+    >
+      <_default
+        className="wds-avatar__image"
+        title="wds-avatar__image"
+      >
+        <_default
+          className="wds-avatar__image"
+          title="wds-avatar__image"
+        >
+          <div
+            className="wds-avatar__image"
+            title="wds-avatar__image"
+          />
+        </_default>
+      </_default>
+    </AvatarImage>
+    <Badge
+      badge="global-discussions-moderator"
+      className=""
+    >
+      <span
+        className="wds-avatar__badge "
+        title="Global Discussions Moderator"
+      >
+        <_default>
+          <_default>
+            <div />
+          </_default>
+        </_default>
+      </span>
+    </Badge>
+  </div>
+</Avatar>
+`;
+
+exports[`Avatar Avatar renders for "helper" badge permission 1`] = `
+<Avatar
+  alt="User avatar"
+  badge="helper"
+>
+  <div
+    className="wds-avatar"
+  >
+    <AvatarImage
+      alt="User avatar"
+    >
+      <_default
+        className="wds-avatar__image"
+        title="wds-avatar__image"
+      >
+        <_default
+          className="wds-avatar__image"
+          title="wds-avatar__image"
+        >
+          <div
+            className="wds-avatar__image"
+            title="wds-avatar__image"
+          />
+        </_default>
+      </_default>
+    </AvatarImage>
+    <Badge
+      badge="helper"
+      className=""
+    >
+      <span
+        className="wds-avatar__badge "
+        title="FANDOM Helper"
+      >
+        <_default>
+          <_default>
+            <div />
+          </_default>
+        </_default>
+      </span>
+    </Badge>
+  </div>
+</Avatar>
+`;
+
+exports[`Avatar Avatar renders for "staff" badge permission 1`] = `
+<Avatar
+  alt="User avatar"
+  badge="staff"
+>
+  <div
+    className="wds-avatar"
+  >
+    <AvatarImage
+      alt="User avatar"
+    >
+      <_default
+        className="wds-avatar__image"
+        title="wds-avatar__image"
+      >
+        <_default
+          className="wds-avatar__image"
+          title="wds-avatar__image"
+        >
+          <div
+            className="wds-avatar__image"
+            title="wds-avatar__image"
+          />
+        </_default>
+      </_default>
+    </AvatarImage>
+    <Badge
+      badge="staff"
+      className=""
+    >
+      <span
+        className="wds-avatar__badge "
+        title="FANDOM Staff"
+      >
+        <_default>
+          <_default>
+            <div />
+          </_default>
+        </_default>
+      </span>
+    </Badge>
+  </div>
+</Avatar>
+`;
+
+exports[`Avatar Avatar renders for "sysop" badge permission 1`] = `
+<Avatar
+  alt="User avatar"
+  badge="sysop"
+>
+  <div
+    className="wds-avatar"
+  >
+    <AvatarImage
+      alt="User avatar"
+    >
+      <_default
+        className="wds-avatar__image"
+        title="wds-avatar__image"
+      >
+        <_default
+          className="wds-avatar__image"
+          title="wds-avatar__image"
+        >
+          <div
+            className="wds-avatar__image"
+            title="wds-avatar__image"
+          />
+        </_default>
+      </_default>
+    </AvatarImage>
+    <Badge
+      badge="sysop"
+      className=""
+    >
+      <span
+        className="wds-avatar__badge "
+        title="Community Admin"
+      >
+        <_default>
+          <_default>
+            <div />
+          </_default>
+        </_default>
+      </span>
+    </Badge>
+  </div>
+</Avatar>
+`;
+
+exports[`Avatar Avatar renders for "threadmoderator" badge permission 1`] = `
+<Avatar
+  alt="User avatar"
+  badge="threadmoderator"
+>
+  <div
+    className="wds-avatar"
+  >
+    <AvatarImage
+      alt="User avatar"
+    >
+      <_default
+        className="wds-avatar__image"
+        title="wds-avatar__image"
+      >
+        <_default
+          className="wds-avatar__image"
+          title="wds-avatar__image"
+        >
+          <div
+            className="wds-avatar__image"
+            title="wds-avatar__image"
+          />
+        </_default>
+      </_default>
+    </AvatarImage>
+    <Badge
+      badge="threadmoderator"
+      className=""
+    >
+      <span
+        className="wds-avatar__badge "
+        title="Discussions Moderator"
+      >
+        <_default>
+          <_default>
+            <div />
+          </_default>
+        </_default>
+      </span>
+    </Badge>
+  </div>
+</Avatar>
+`;
+
+exports[`Avatar Avatar renders for "vstf" badge permission 1`] = `
+<Avatar
+  alt="User avatar"
+  badge="vstf"
+>
+  <div
+    className="wds-avatar"
+  >
+    <AvatarImage
+      alt="User avatar"
+    >
+      <_default
+        className="wds-avatar__image"
+        title="wds-avatar__image"
+      >
+        <_default
+          className="wds-avatar__image"
+          title="wds-avatar__image"
+        >
+          <div
+            className="wds-avatar__image"
+            title="wds-avatar__image"
+          />
+        </_default>
+      </_default>
+    </AvatarImage>
+    <Badge
+      badge="vstf"
+      className=""
+    >
+      <span
+        className="wds-avatar__badge "
+        title="VSTF"
+      >
+        <_default>
+          <_default>
+            <div />
+          </_default>
+        </_default>
+      </span>
+    </Badge>
+  </div>
+</Avatar>
+`;
+
+exports[`Avatar Avatar renders when incorrect badgePermission is set 1`] = `
 <Avatar
   alt="User avatar"
   badge="someIncorrectBadgePermission"
@@ -34,52 +349,7 @@ exports[`Avatar renders when incorrect badgePermission is set 1`] = `
 </Avatar>
 `;
 
-exports[`Avatar renders with badge 1`] = `
-<Avatar
-  alt="User avatar"
-  badge="admin"
->
-  <div
-    className="wds-avatar"
-  >
-    <AvatarImage
-      alt="User avatar"
-    >
-      <_default
-        className="wds-avatar__image"
-        title="wds-avatar__image"
-      >
-        <_default
-          className="wds-avatar__image"
-          title="wds-avatar__image"
-        >
-          <div
-            className="wds-avatar__image"
-            title="wds-avatar__image"
-          />
-        </_default>
-      </_default>
-    </AvatarImage>
-    <Badge
-      badge="admin"
-      className=""
-    >
-      <span
-        className="wds-avatar__badge "
-        title="Community Admin"
-      >
-        <_default>
-          <_default>
-            <div />
-          </_default>
-        </_default>
-      </span>
-    </Badge>
-  </div>
-</Avatar>
-`;
-
-exports[`Avatar renders with default props 1`] = `
+exports[`Avatar Avatar renders with default props 1`] = `
 <Avatar
   alt="User avatar"
 >
@@ -108,7 +378,7 @@ exports[`Avatar renders with default props 1`] = `
 </Avatar>
 `;
 
-exports[`Avatar renders with link builder 1`] = `
+exports[`Avatar Avatar renders with link builder 1`] = `
 <Avatar
   alt="User avatar"
   linkBuilder={[Function]}
@@ -140,7 +410,7 @@ exports[`Avatar renders with link builder 1`] = `
 </Avatar>
 `;
 
-exports[`Avatar renders with props 1`] = `
+exports[`Avatar Avatar renders with props 1`] = `
 <Avatar
   alt="alt"
   badge="admin"
@@ -171,18 +441,7 @@ exports[`Avatar renders with props 1`] = `
     <Badge
       badge="admin"
       className=""
-    >
-      <span
-        className="wds-avatar__badge "
-        title="Community Admin"
-      >
-        <_default>
-          <_default>
-            <div />
-          </_default>
-        </_default>
-      </span>
-    </Badge>
+    />
   </div>
 </Avatar>
 `;

--- a/source/components/Avatar/index.js
+++ b/source/components/Avatar/index.js
@@ -28,7 +28,7 @@ Avatar.propTypes = {
     /** Badge to display for avatar. */
     badge: PropTypes.oneOf(
         [
-            'admin', 'content-moderator', 'discussion-moderator', 'sysop',
+            'content-moderator', 'discussion-moderator', 'sysop',
             'global-discussions-moderator', 'helper', 'staff', 'vstf', '',
         ],
     ),

--- a/source/components/Avatar/index.spec.js
+++ b/source/components/Avatar/index.spec.js
@@ -32,7 +32,7 @@ describe('Avatar', () => {
         'sysop', 'content-moderator', 'threadmoderator', 'global-discussions-moderator', 'staff', 'vstf', 'helper',
     ];
 
-    badgePermissionTestCases.forEach(badge => {
+    badgePermissionTestCases.forEach((badge) => {
         test(`Avatar renders for "${badge}" badge permission`, () => {
             const props = { badge };
             const component = mount(<Avatar {...props} />);

--- a/source/components/Avatar/index.spec.js
+++ b/source/components/Avatar/index.spec.js
@@ -4,44 +4,50 @@ import sinon from 'sinon';
 
 import Avatar from './index';
 
-test('Avatar renders with default props', () => {
-    const component = mount(<Avatar />);
-    expect(component).toMatchSnapshot();
-});
+describe('Avatar', () => {
+    test('Avatar renders with default props', () => {
+        const component = mount(<Avatar />);
+        expect(component).toMatchSnapshot();
+    });
 
-test('Avatar renders with props', () => {
-    const props = {
-        alt: 'alt',
-        badge: 'admin',
-        className: 'class-name',
-        href: 'href',
-        src: 'src',
-        title: 'title',
-    };
-    const component = mount(<Avatar {...props} />);
-    expect(component).toMatchSnapshot();
-});
+    test('Avatar renders with props', () => {
+        const props = {
+            alt: 'alt',
+            badge: 'admin',
+            className: 'class-name',
+            href: 'href',
+            src: 'src',
+            title: 'title',
+        };
+        const component = mount(<Avatar {...props} />);
+        expect(component).toMatchSnapshot();
+    });
 
-test('Avatar renders with link builder', () => {
-    const component = mount(<Avatar linkBuilder={avatarImage => <div>{avatarImage}</div>} />);
-    expect(component).toMatchSnapshot();
-});
+    test('Avatar renders with link builder', () => {
+        const component = mount(<Avatar linkBuilder={avatarImage => <div>{avatarImage}</div>} />);
+        expect(component).toMatchSnapshot();
+    });
 
-test('Avatar renders with badge', () => {
-    const props = {
-        badge: 'admin',
-    };
-    const component = mount(<Avatar {...props} />);
-    expect(component).toMatchSnapshot();
-});
+    const badgePermissionTestCases = [
+        'sysop', 'content-moderator', 'threadmoderator', 'global-discussions-moderator', 'staff', 'vstf', 'helper',
+    ];
 
-test('Avatar renders when incorrect badgePermission is set', () => {
-    // silencing Warning: Failed prop type: Invalid prop `badge` of value `someIncorrectBadgePermission` supplied to `Avatar`, expected one of ["admin","content-moderator","discussion-moderator","global-discussions-moderator","helper","staff","vstf"]
-    const consoleStub = sinon.stub(console, 'error');
-    const props = {
-        badge: 'someIncorrectBadgePermission',
-    };
-    const component = mount(<Avatar {...props} />);
-    consoleStub.restore();
-    expect(component).toMatchSnapshot();
+    badgePermissionTestCases.forEach(badge => {
+        test(`Avatar renders for "${badge}" badge permission`, () => {
+            const props = { badge };
+            const component = mount(<Avatar {...props} />);
+            expect(component).toMatchSnapshot();
+        });
+    });
+
+    test('Avatar renders when incorrect badgePermission is set', () => {
+        // silencing Warning: Failed prop type: Invalid prop `badge` of value `someIncorrectBadgePermission` supplied to `Avatar`, expected one of ["admin","content-moderator","discussion-moderator","global-discussions-moderator","helper","staff","vstf"]
+        const consoleStub = sinon.stub(console, 'error');
+        const props = {
+            badge: 'someIncorrectBadgePermission',
+        };
+        const component = mount(<Avatar {...props} />);
+        consoleStub.restore();
+        expect(component).toMatchSnapshot();
+    });
 });

--- a/source/components/StyledAvatar/__snapshots__/index.spec.js.snap
+++ b/source/components/StyledAvatar/__snapshots__/index.spec.js.snap
@@ -193,7 +193,7 @@ exports[`Avatar renders when incorrect badgePermission is set 1`] = `
 exports[`Avatar renders with badge 1`] = `
 <StyledAvatar
   alt="User avatar"
-  badge="admin"
+  badge="sysop"
   size={48}
 >
   <StyledAvatar__Wrapper
@@ -313,13 +313,13 @@ exports[`Avatar renders with badge 1`] = `
           </StyledComponent>
         </DefaultAvatar>
         <Badge
-          badge="admin"
+          badge="sysop"
           className=""
           diameter={48}
           size={20.1872}
         >
           <StyledComponent
-            badge="admin"
+            badge="sysop"
             className=""
             diameter={48}
             forwardedComponent={
@@ -367,7 +367,7 @@ exports[`Avatar renders with badge 1`] = `
             size={20.1872}
           >
             <Badge
-              badge="admin"
+              badge="sysop"
               className="Badge-sc-1a5ie29-0 cwhJAF"
               diameter={48}
               size={20.1872}
@@ -651,7 +651,7 @@ exports[`Avatar renders with link builder 1`] = `
 exports[`Avatar renders with props 1`] = `
 <StyledAvatar
   alt="alt"
-  badge="admin"
+  badge="sysop"
   className="class-name"
   href="href"
   size={48}
@@ -817,13 +817,13 @@ exports[`Avatar renders with props 1`] = `
           </StyledComponent>
         </StyledAvatar__Link>
         <Badge
-          badge="admin"
+          badge="sysop"
           className=""
           diameter={48}
           size={20.1872}
         >
           <StyledComponent
-            badge="admin"
+            badge="sysop"
             className=""
             diameter={48}
             forwardedComponent={
@@ -871,7 +871,7 @@ exports[`Avatar renders with props 1`] = `
             size={20.1872}
           >
             <Badge
-              badge="admin"
+              badge="sysop"
               className="Badge-sc-1a5ie29-0 cwhJAF"
               diameter={48}
               size={20.1872}
@@ -898,7 +898,7 @@ exports[`Avatar renders with props 1`] = `
 exports[`Avatar renders with size >= 48px 1`] = `
 <StyledAvatar
   alt="User avatar"
-  badge="admin"
+  badge="sysop"
   size="50"
 >
   <StyledAvatar__Wrapper
@@ -1018,13 +1018,13 @@ exports[`Avatar renders with size >= 48px 1`] = `
           </StyledComponent>
         </DefaultAvatar>
         <Badge
-          badge="admin"
+          badge="sysop"
           className=""
           diameter={50}
           size={20.695}
         >
           <StyledComponent
-            badge="admin"
+            badge="sysop"
             className=""
             diameter={50}
             forwardedComponent={
@@ -1072,7 +1072,7 @@ exports[`Avatar renders with size >= 48px 1`] = `
             size={20.695}
           >
             <Badge
-              badge="admin"
+              badge="sysop"
               className="Badge-sc-1a5ie29-0 juzlSY"
               diameter={50}
               size={20.695}
@@ -1226,7 +1226,7 @@ exports[`Avatar renders with size >= 120px 1`] = `
 exports[`Avatar renders with size 30px 1`] = `
 <StyledAvatar
   alt="User avatar"
-  badge="admin"
+  badge="sysop"
   size="30"
 >
   <StyledAvatar__Wrapper
@@ -1346,13 +1346,13 @@ exports[`Avatar renders with size 30px 1`] = `
           </StyledComponent>
         </DefaultAvatar>
         <Badge
-          badge="admin"
+          badge="sysop"
           className=""
           diameter={30}
           size={15.617}
         >
           <StyledComponent
-            badge="admin"
+            badge="sysop"
             className=""
             diameter={30}
             forwardedComponent={
@@ -1400,7 +1400,7 @@ exports[`Avatar renders with size 30px 1`] = `
             size={15.617}
           >
             <Badge
-              badge="admin"
+              badge="sysop"
               className="Badge-sc-1a5ie29-0 clhjIq"
               diameter={30}
               size={15.617}

--- a/source/components/StyledAvatar/index.js
+++ b/source/components/StyledAvatar/index.js
@@ -94,7 +94,7 @@ StyledAvatar.propTypes = {
     /** Badge to display for avatar. */
     badge: PropTypes.oneOf(
         [
-            'admin', 'content-moderator', 'discussion-moderator', 'sysop',
+            'content-moderator', 'discussion-moderator', 'sysop',
             'global-discussions-moderator', 'helper', 'staff', 'vstf', '',
         ],
     ),

--- a/source/components/StyledAvatar/index.spec.js
+++ b/source/components/StyledAvatar/index.spec.js
@@ -25,12 +25,12 @@ test('Avatar renders with default props', () => {
 });
 
 test('Avatar renders with size 30px', () => {
-    const component = mount(<StyledAvatar size="30" badge="admin" />);
+    const component = mount(<StyledAvatar size="30" badge="sysop" />);
     expect(component).toMatchSnapshot();
 });
 
 test('Avatar renders with size >= 48px', () => {
-    const component = mount(<StyledAvatar size="50" badge="admin" />);
+    const component = mount(<StyledAvatar size="50" badge="sysop" />);
     expect(component).toMatchSnapshot();
 });
 
@@ -42,7 +42,7 @@ test('Avatar renders with size >= 120px', () => {
 test('Avatar renders with props', () => {
     const props = {
         alt: 'alt',
-        badge: 'admin',
+        badge: 'sysop',
         className: 'class-name',
         href: 'href',
         src: 'src',
@@ -59,7 +59,7 @@ test('Avatar renders with link builder', () => {
 
 test('Avatar renders with badge', () => {
     const props = {
-        badge: 'admin',
+        badge: 'sysop',
     };
     const component = mount(<StyledAvatar {...props} />);
     expect(component).toMatchSnapshot();


### PR DESCRIPTION
There is no such badge permission as `discussion-moderator` or `admin.` The respective permissions are named `threadmoderator` and `sysop`. This PR updates the badge mapping to ensure that moderators and admins have a proper badge displayed.

https://wikia-inc.atlassian.net/browse/IW-1859