### PR TITLE
:wrench: Make PRs uglier, but easier to read by unfolding spec.snap.js files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.spec.js.snap linguist-generated


### PR DESCRIPTION
As discussed

@xkxd 