### PR TITLE
cake-5067 | Added isSandbox function to react common

### DIFF
--- a/source/utils/ENVIRONMENT.md
+++ b/source/utils/ENVIRONMENT.md
@@ -3,7 +3,7 @@ The `utils/environment.js` offers a few environment config helpers including det
 Usage:
 
 ```js static
-import { isBrowser, isFandomCom, getServicesBaseURL, isProduction, getEventLoggerBase } from '@wikia/react-common/utils/environment';
+import { isBrowser, isFandomCom, getServicesBaseURL, isProduction, isSandbox, getEventLoggerBase } from '@wikia/react-common/utils/environment';
 
 isProduction();         // checks if the app was built with the production flag (might not be in a prod env though)
 isBrowser();            // checks if the window global is available

--- a/source/utils/ENVIRONMENT.md
+++ b/source/utils/ENVIRONMENT.md
@@ -1,4 +1,4 @@
-The `utils/environment.js` offers a few environment config helpers including detection of browser and service urls based on the env. 
+The `utils/environment.js` offers a few environment config helpers including detection of browser and service urls based on the env.
 
 Usage:
 
@@ -6,10 +6,10 @@ Usage:
 import { isBrowser, isFandomCom, getServicesBaseURL, isProduction, getEventLoggerBase } from '@wikia/react-common/utils/environment';
 
 isProduction();         // checks if the app was built with the production flag (might not be in a prod env though)
-isBrowser();            // checks if the window global is available 
-isFandomCom();          // used to determine the end points for services 
+isBrowser();            // checks if the window global is available
+isFandomCom();          // used to determine the end points for services
+isSandbox();            // checks if url is a sandbox
 
 getServicesBaseURL();   // gives the correct services url base on the environment
 getEventLoggerBase();   // correct event logger url
 ```
-

--- a/source/utils/environment.js
+++ b/source/utils/environment.js
@@ -41,6 +41,10 @@ export function isSandbox() {
     if (get(window, 'window.fandom.config.environment.env', '').indexOf('sandbox') > -1) {
         return true;
     }
+    // upstream
+    if (get(window, 'window.upstream.env', '').indexOf('sandbox') > -1) {
+        return true;
+    }
 
     return false;
 }

--- a/source/utils/environment.js
+++ b/source/utils/environment.js
@@ -30,15 +30,15 @@ export function isSandbox() {
         return false;
     }
     // fepo
-    if (isBrowser() && get(window, 'window.fandom.environment.environment', '').indexOf('sandbox') > -1) {
+    if (get(window, 'window.fandom.environment.environment', '').indexOf('sandbox') > -1) {
         return true;
     }
     // mw
-    if (isBrowser() && get(window, 'window.wgTransactionContext.env', '').indexOf('sandbox') > -1) {
+    if (get(window, 'window.wgTransactionContext.env', '').indexOf('sandbox') > -1) {
         return true;
     }
     // upstream
-    if (isBrowser() && get(window, 'window.fandom.config.environment.env', '').indexOf('sandbox') > -1) {
+    if (get(window, 'window.fandom.config.environment.env', '').indexOf('sandbox') > -1) {
         return true;
     }
 

--- a/source/utils/environment.js
+++ b/source/utils/environment.js
@@ -1,3 +1,5 @@
+import { get } from 'lodash';
+
 export function isBrowser() {
     return typeof window !== 'undefined';
 }
@@ -21,4 +23,24 @@ export function getServicesBaseURL() {
 
 export function getEventLoggerBase() {
     return `${getServicesBaseURL()}event-logger`;
+}
+
+export function isSandbox() {
+    if (!isBrowser() || isProduction()) {
+        return false;
+    }
+    // fepo
+    if (isBrowser() && get(window, 'window.fandom.environment.environment', '').indexOf('sandbox') > -1) {
+        return true;
+    }
+    // mw
+    if (isBrowser() && get(window, 'window.wgTransactionContext.env', '').indexOf('sandbox') > -1) {
+        return true;
+    }
+    // upstream
+    if (isBrowser() && get(window, 'window.fandom.config.environment.env', '').indexOf('sandbox') > -1) {
+        return true;
+    }
+
+    return false;
 }

--- a/source/utils/environment.js
+++ b/source/utils/environment.js
@@ -26,7 +26,7 @@ export function getEventLoggerBase() {
 }
 
 export function isSandbox() {
-    if (!isBrowser() || isProduction()) {
+    if (!isBrowser()) {
         return false;
     }
     // fepo
@@ -37,7 +37,7 @@ export function isSandbox() {
     if (get(window, 'window.wgTransactionContext.env', '').indexOf('sandbox') > -1) {
         return true;
     }
-    // upstream
+    // f2
     if (get(window, 'window.fandom.config.environment.env', '').indexOf('sandbox') > -1) {
         return true;
     }

--- a/source/utils/environment.spec.js
+++ b/source/utils/environment.spec.js
@@ -1,0 +1,56 @@
+import { isSandbox } from './environment';
+
+// Unit tests for isSandbox() in multiple environments
+describe('Tests for is Sandbox: ', () => {
+    test('It should return false when window object property is undefined', () => {
+        expect(isSandbox()).toEqual(false);
+    });
+
+    test('It should return false if on production', () => {
+        // simulate window object that is not on a sandbox
+        global.window.fandom = {
+            config: {
+                environment: {
+                    env: 'production',
+                },
+            },
+        };
+
+        expect(isSandbox()).toEqual(false);
+    });
+
+    test('It should return true if sandbox on fepo', () => {
+        // simulate fepo's window object with sandbox environment
+        global.window.fandom = {
+            environment: {
+                environment: 'sandbox',
+            },
+        };
+
+        expect(isSandbox()).toEqual(true);
+    });
+
+    test('It should return true if sandbox is on mediawiki', () => {
+        // simulate mw's window object with sandbox environment
+        global.window = {
+            wgTransactionContext: {
+                env: 'sandbox',
+            },
+        };
+
+        expect(isSandbox()).toEqual(true);
+    });
+
+    test('It should return true if sandbox is on upstream', () => {
+        // simulate upstream's window object with sandbox environment
+        global.window.fandom = {
+            config: {
+                environment: {
+                    env: 'sandbox',
+                },
+            },
+        };
+
+        expect(isSandbox()).toEqual(true);
+    });
+});

--- a/source/utils/environment.spec.js
+++ b/source/utils/environment.spec.js
@@ -2,6 +2,22 @@ import { isSandbox } from './environment';
 
 // Unit tests for isSandbox() in multiple environments
 describe('Tests for is Sandbox: ', () => {
+    beforeEach(() => {
+        // reset global window properties for
+
+        // fepo & f2
+        delete global.window.fandom;
+        global.window.fandom = {};
+
+        // mediawiki
+        delete global.window.wgTransactionContext;
+        global.window.wgTransactionContext = {};
+
+        // upstream
+        delete global.window.upstream;
+        global.window.upstream = {};
+    });
+
     test('It should return false when window object property is undefined', () => {
         expect(isSandbox()).toEqual(false);
     });
@@ -32,23 +48,30 @@ describe('Tests for is Sandbox: ', () => {
 
     test('It should return true if sandbox is on mediawiki', () => {
         // simulate mw's window object with sandbox environment
-        global.window = {
-            wgTransactionContext: {
-                env: 'sandbox',
-            },
+        global.window.wgTransactionContext = {
+            env: 'sandbox',
         };
 
         expect(isSandbox()).toEqual(true);
     });
 
     test('It should return true if sandbox is on f2', () => {
-        // simulate upstream's window object with sandbox environment
+        // simulate f2's window object with sandbox environment
         global.window.fandom = {
             config: {
                 environment: {
                     env: 'sandbox',
                 },
             },
+        };
+
+        expect(isSandbox()).toEqual(true);
+    });
+
+    test('It should return true if sandbox is on upstream', () => {
+        // simulate upstream's window object with sandbox environment
+        global.window.upstream = {
+            env: 'sandbox',
         };
 
         expect(isSandbox()).toEqual(true);

--- a/source/utils/environment.spec.js
+++ b/source/utils/environment.spec.js
@@ -41,7 +41,7 @@ describe('Tests for is Sandbox: ', () => {
         expect(isSandbox()).toEqual(true);
     });
 
-    test('It should return true if sandbox is on upstream', () => {
+    test('It should return true if sandbox is on f2', () => {
         // simulate upstream's window object with sandbox environment
         global.window.fandom = {
             config: {

--- a/source/utils/environment.spec.js
+++ b/source/utils/environment.spec.js
@@ -1,28 +1,25 @@
 import { isSandbox } from './environment';
 
 // Unit tests for isSandbox() in multiple environments
-describe('Tests for is Sandbox: ', () => {
+describe('Unit tests for isSandbox() ', () => {
     beforeEach(() => {
         // reset global window properties for
 
         // fepo & f2
         delete global.window.fandom;
-        global.window.fandom = {};
 
         // mediawiki
         delete global.window.wgTransactionContext;
-        global.window.wgTransactionContext = {};
 
         // upstream
         delete global.window.upstream;
-        global.window.upstream = {};
     });
 
-    test('It should return false when window object property is undefined', () => {
+    test('should return false when window object property is undefined', () => {
         expect(isSandbox()).toEqual(false);
     });
 
-    test('It should return false if on production', () => {
+    test('should return false if on production', () => {
         // simulate window object that is not on a sandbox
         global.window.fandom = {
             config: {
@@ -35,7 +32,7 @@ describe('Tests for is Sandbox: ', () => {
         expect(isSandbox()).toEqual(false);
     });
 
-    test('It should return true if sandbox on fepo', () => {
+    test('should return true if sandbox on fepo', () => {
         // simulate fepo's window object with sandbox environment
         global.window.fandom = {
             environment: {
@@ -46,7 +43,7 @@ describe('Tests for is Sandbox: ', () => {
         expect(isSandbox()).toEqual(true);
     });
 
-    test('It should return true if sandbox is on mediawiki', () => {
+    test('should return true if sandbox is on mediawiki', () => {
         // simulate mw's window object with sandbox environment
         global.window.wgTransactionContext = {
             env: 'sandbox',
@@ -55,7 +52,7 @@ describe('Tests for is Sandbox: ', () => {
         expect(isSandbox()).toEqual(true);
     });
 
-    test('It should return true if sandbox is on f2', () => {
+    test('should return true if sandbox is on f2', () => {
         // simulate f2's window object with sandbox environment
         global.window.fandom = {
             config: {
@@ -68,7 +65,7 @@ describe('Tests for is Sandbox: ', () => {
         expect(isSandbox()).toEqual(true);
     });
 
-    test('It should return true if sandbox is on upstream', () => {
+    test('should return true if sandbox is on upstream', () => {
         // simulate upstream's window object with sandbox environment
         global.window.upstream = {
             env: 'sandbox',


### PR DESCRIPTION
Wanted a check for sandbox environment that could be reused across different apps. This function currently checks if it's on a sandbox environment by looking for properties on the window object. Currently can be used to check on:
- fepo
- mediawiki
- f2
- upstream