### PR TITLE
Reduce size of logging 

### DIFF
--- a/source/hocs/withErrorBoundary/index.js
+++ b/source/hocs/withErrorBoundary/index.js
@@ -21,8 +21,8 @@ class ErrorBoundary extends React.Component {
 
         if (!this.props.skipLog) {
             logErrorEvent(this.props.appName, this.props.appVersion, `error-boundary-${this.props.name}`, {
-                errorStack: error.stack.substr(0, 1000), // too much prevents the log from showing up
                 errorMessage: error.message,
+                errorStack: error.stack.substr(0, 1000), // too much prevents the log from showing up
             });
         }
     }

--- a/source/hocs/withErrorBoundary/index.js
+++ b/source/hocs/withErrorBoundary/index.js
@@ -21,8 +21,8 @@ class ErrorBoundary extends React.Component {
 
         if (!this.props.skipLog) {
             logErrorEvent(this.props.appName, this.props.appVersion, `error-boundary-${this.props.name}`, {
-                errorStack: error.stack,
-                componentStack: info.componentStack,
+                errorStack: error.stack.substr(0, 1000), // too much prevents the log from showing up
+                errorMessage: error.message,
             });
         }
     }


### PR DESCRIPTION
The logger service wasn't able to handle logging out the entire stack of error. Reduce it and add the error message to the output. 

@Wikia/cake @vforge 