### PR TITLE
SITE-217 | Add missing notification content types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikia/react-common",
-  "version": "12.9.4",
+  "version": "12.9.5-test.9",
   "description": "Wikia's reusable React parts",
   "repository": "git@github.com:Wikia/react-common.git",
   "license": "UNLICENSED",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikia/react-common",
-  "version": "12.9.5-test.9",
+  "version": "12.9.4",
   "description": "Wikia's reusable React parts",
   "repository": "git@github.com:Wikia/react-common.git",
   "license": "UNLICENSED",

--- a/source/components/GlobalNavigation/components/Notifications/CardText.js
+++ b/source/components/GlobalNavigation/components/Notifications/CardText.js
@@ -213,7 +213,7 @@ function getMessageWallPostMessageBody(t, {
     let wallOwner = metadata && metadata.wallOwnerName;
 
     if (!wallOwner) {
-        wallOwner = this.getMessageWallUser(uri);
+        wallOwner = getMessageWallUser(uri);
     }
 
     const isOwnWall = wallOwner === currentUserName;

--- a/source/components/GlobalNavigation/components/Notifications/CardText.js
+++ b/source/components/GlobalNavigation/components/Notifications/CardText.js
@@ -10,6 +10,9 @@ import {
     isDiscussionReplyUpvote,
     isPostAtMention,
     isThreadAtMention,
+    isMessageWallPost,
+    isMessageWallThread,
+    isTalkPageMessage,
 } from '../../models/notificationTypes';
 import I18nNamespaceContext from '../../context/I18nNamespaceContext';
 import { useUserData } from '../../context/UserContext';
@@ -201,6 +204,18 @@ const getText = (translateFunc, model, userData) => {
 
     if (isArticleCommentReplyAtMention(type)) {
         return getArticleCommentReplyAtMentionMessageBody(translateFunc, { latestActors, title });
+    }
+
+    if (isMessageWallThread(type)) {
+        return 'message wall thread';
+    }
+
+    if (isMessageWallPost(type)) {
+        return 'message wall post';
+    }
+
+    if (isTalkPageMessage(type)) {
+        return 'talk page message';
     }
 
     return null;

--- a/source/components/GlobalNavigation/components/Notifications/CardText.js
+++ b/source/components/GlobalNavigation/components/Notifications/CardText.js
@@ -244,6 +244,11 @@ function getMessageWallPostMessageBody(t, { latestActors, title, metadata, uri, 
     return t('notifications-wall-reply', args);
 }
 
+function getTalkPageMessageBody(t, { latestActors }) {
+    const user = getArticleCommentNotificationUsername(t, latestActors);
+    return t('notifications-talk-page-message', { user });
+}
+
 const getText = (translateFunc, model, userData) => {
     const {
         type,
@@ -346,7 +351,7 @@ const getText = (translateFunc, model, userData) => {
     }
 
     if (isTalkPageMessage(type)) {
-        return 'talk page message';
+        return getTalkPageMessageBody(translateFunc, { latestActors });
     }
 
     return null;

--- a/source/components/GlobalNavigation/components/Notifications/CardText.js
+++ b/source/components/GlobalNavigation/components/Notifications/CardText.js
@@ -174,16 +174,17 @@ function getArticleCommentReplyAtMentionMessageBody(t, { latestActors, title }) 
     return t('notifications-article-comment-reply-mention', { user, articleTitle: bold(title) });
 }
 
-function getMessageWallThreadMessageBody(t, { latestActors, title, metadata, uri }) {
+function getMessageWallThreadMessageBody(t, { latestActors, title, metadata, uri, userData }) {
     const user = getArticleCommentNotificationUsername(t, latestActors);
-    console.log('wallOwnerName', typeof metadata);
+    const currentUserName = userData?.username;
+
     let wallOwner = metadata && metadata.wallOwnerName;
 
     if (!wallOwner) {
         wallOwner = getMessageWallUser(uri);
     }
 
-    const isOwnWall = wallOwner === user;
+    const isOwnWall = wallOwner === currentUserName;
     const args = {
         postTitle: bold(escapeHtml(title)),
         wallOwner: escapeHtml(wallOwner),
@@ -198,15 +199,24 @@ function getMessageWallThreadMessageBody(t, { latestActors, title, metadata, uri
     return t('notifications-wall-post', { firstUser: user, ...args });
 }
 
-function getMessageWallPostMessageBody(t, { latestActors, title, metadata, uri, totalUniqueActors, refersToAuthorName }) {
+function getMessageWallPostMessageBody(t, {
+    latestActors,
+    title,
+    metadata,
+    uri,
+    totalUniqueActors,
+    refersToAuthorName,
+    userData,
+}) {
     const user = getArticleCommentNotificationUsername(t, latestActors);
+    const currentUserName = userData?.username;
     let wallOwner = metadata && metadata.wallOwnerName;
 
     if (!wallOwner) {
         wallOwner = this.getMessageWallUser(uri);
     }
 
-    const isOwnWall = wallOwner === user;
+    const isOwnWall = wallOwner === currentUserName;
     const args = {
         postTitle: bold(escapeHtml(title)),
         wallOwner: escapeHtml(wallOwner),
@@ -336,6 +346,7 @@ const getText = (translateFunc, model, userData) => {
             title,
             metadata,
             uri,
+            userData,
         });
     }
 
@@ -347,6 +358,7 @@ const getText = (translateFunc, model, userData) => {
             uri,
             totalUniqueActors,
             refersToAuthorName,
+            userData,
         });
     }
 

--- a/source/components/GlobalNavigation/components/Notifications/CardText.spec.js
+++ b/source/components/GlobalNavigation/components/Notifications/CardText.spec.js
@@ -378,6 +378,20 @@ describe('Wall post', () => {
         })).toMatchSnapshot();
     });
 
+    test('CardText renders correctly when wall URL is invalid', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.messageWallPost,
+                latestActors: [{ id: 0, name: null }],
+                totalUniqueActors: 1,
+                title: 'Article <b>Title</b>',
+                uri: 'https://elo.test.com/wiki/Test',
+                refersToAuthorName: 'Test',
+                metadata: {},
+            },
+        })).toMatchSnapshot();
+    });
+
     test('CardText renders correctly for multiple replies on own wall', () => {
         expect(renderComponent({
             model: {

--- a/source/components/GlobalNavigation/components/Notifications/CardText.spec.js
+++ b/source/components/GlobalNavigation/components/Notifications/CardText.spec.js
@@ -462,3 +462,14 @@ describe('Wall post', () => {
         })).toMatchSnapshot();
     });
 });
+
+describe('Talk page', () => {
+    test('CardText renders correctly', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.talkPageMessage,
+                latestActors: [{ id: 123, name: 'Test' }],
+            },
+        })).toMatchSnapshot();
+    });
+});

--- a/source/components/GlobalNavigation/components/Notifications/CardText.spec.js
+++ b/source/components/GlobalNavigation/components/Notifications/CardText.spec.js
@@ -314,3 +314,45 @@ describe('Article Comments at mentions', () => {
         })).toMatchSnapshot();
     });
 });
+
+describe('Wall thread', () => {
+    beforeEach(() => {
+        useUserData.mockReturnValue({ id: '123', username: 'Test' });
+    });
+
+    test('CardText renders correctly when metadata is missing', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.messageWallThread,
+                latestActors: [{ id: 0, name: null }],
+                totalUniqueActors: 1,
+                title: 'Article <b>Title</b>',
+                uri: 'https://elo.test.com/wiki/Message_Wall:Test',
+            },
+        })).toMatchSnapshot();
+    });
+
+    test('CardText renders correctly for own wall', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.messageWallThread,
+                latestActors: [{ id: 123, name: 'Test' }],
+                totalUniqueActors: 1,
+                title: 'Article <b>Title</b>',
+                uri: 'https://elo.test.com/wiki/Message_Wall:Test',
+            },
+        })).toMatchSnapshot();
+    });
+
+    test('CardText renders correctly for others wall', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.messageWallThread,
+                latestActors: [{ id: 321, name: 'Test2' }],
+                totalUniqueActors: 1,
+                title: 'Article <b>Title</b>',
+                uri: 'https://elo.test.com/wiki/Message_Wall:Test2',
+            },
+        })).toMatchSnapshot();
+    });
+});

--- a/source/components/GlobalNavigation/components/Notifications/CardText.spec.js
+++ b/source/components/GlobalNavigation/components/Notifications/CardText.spec.js
@@ -340,6 +340,7 @@ describe('Wall thread', () => {
                 totalUniqueActors: 1,
                 title: 'Article <b>Title</b>',
                 uri: 'https://elo.test.com/wiki/Message_Wall:Test',
+                metadata: { wallOwnerName: 'Test' },
             },
         })).toMatchSnapshot();
     });
@@ -352,6 +353,111 @@ describe('Wall thread', () => {
                 totalUniqueActors: 1,
                 title: 'Article <b>Title</b>',
                 uri: 'https://elo.test.com/wiki/Message_Wall:Test2',
+                metadata: { wallOwnerName: 'Test2' },
+            },
+        })).toMatchSnapshot();
+    });
+});
+
+describe('Wall post', () => {
+    beforeEach(() => {
+        useUserData.mockReturnValue({ id: '123', username: 'Test' });
+    });
+
+    test('CardText renders correctly when metadata is missing', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.messageWallPost,
+                latestActors: [{ id: 0, name: null }],
+                totalUniqueActors: 1,
+                title: 'Article <b>Title</b>',
+                uri: 'https://elo.test.com/wiki/Message_Wall:Test',
+                refersToAuthorName: 'Test',
+                metadata: {},
+            },
+        })).toMatchSnapshot();
+    });
+
+    test('CardText renders correctly for multiple replies on own wall', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.messageWallPost,
+                latestActors: [{ id: 0, name: null }],
+                totalUniqueActors: 3,
+                title: 'Article <b>Title</b>',
+                uri: 'https://elo.test.com/wiki/Message_Wall:Test',
+                refersToAuthorName: 'TestOther',
+                metadata: { wallOwnerName: 'Test' },
+            },
+        })).toMatchSnapshot();
+    });
+
+    test('CardText renders correctly for reply to own message when multiple actors', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.messageWallPost,
+                latestActors: [{ id: 123, name: 'Test' }],
+                totalUniqueActors: 3,
+                title: 'Article <b>Title</b>',
+                uri: 'https://elo.test.com/wiki/Message_Wall:TestOther',
+                refersToAuthorName: 'Test',
+                metadata: { wallOwnerName: 'TestOther' },
+            },
+        })).toMatchSnapshot();
+    });
+
+    test('CardText renders correctly for multiple replies on others wall', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.messageWallPost,
+                latestActors: [{ id: 123, name: 'Test' }],
+                totalUniqueActors: 3,
+                title: 'Article <b>Title</b>',
+                uri: 'https://elo.test.com/wiki/Message_Wall:TestOther',
+                refersToAuthorName: 'TestOther',
+                metadata: { wallOwnerName: 'TestOther' },
+            },
+        })).toMatchSnapshot();
+    });
+
+    test('CardText renders correctly for single reply on own wall', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.messageWallPost,
+                latestActors: [{ id: 123, name: 'Test' }],
+                totalUniqueActors: 1,
+                title: 'Article <b>Title</b>',
+                uri: 'https://elo.test.com/wiki/Message_Wall:Test',
+                refersToAuthorName: 'TestOther',
+                metadata: { wallOwnerName: 'Test' },
+            },
+        })).toMatchSnapshot();
+    });
+
+    test('CardText renders correctly for single reply to own message', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.messageWallPost,
+                latestActors: [{ id: 123, name: 'Test' }],
+                totalUniqueActors: 1,
+                title: 'Article <b>Title</b>',
+                uri: 'https://elo.test.com/wiki/Message_Wall:TestOther',
+                refersToAuthorName: 'Test',
+                metadata: { wallOwnerName: 'TestOther' },
+            },
+        })).toMatchSnapshot();
+    });
+
+    test('CardText renders correctly for single reply on others wall', () => {
+        expect(renderComponent({
+            model: {
+                type: notificationTypes.messageWallPost,
+                latestActors: [{ id: 123, name: 'Test' }],
+                totalUniqueActors: 1,
+                title: 'Article <b>Title</b>',
+                uri: 'https://elo.test.com/wiki/Message_Wall:TestOther',
+                refersToAuthorName: 'TestOther',
+                metadata: { wallOwnerName: 'TestOther' },
             },
         })).toMatchSnapshot();
     });

--- a/source/components/GlobalNavigation/components/Notifications/MarkAsReadIcon.js
+++ b/source/components/GlobalNavigation/components/Notifications/MarkAsReadIcon.js
@@ -12,6 +12,9 @@ import {
     isDiscussionReply,
     isPostAtMention,
     isThreadAtMention,
+    isMessageWallPost,
+    isMessageWallThread,
+    isTalkPageMessage,
 } from '../../models/notificationTypes';
 
 function isCommentNotifictionType(type) {
@@ -19,7 +22,7 @@ function isCommentNotifictionType(type) {
 }
 
 function getIconName(type) {
-    if (isCommentNotifictionType(type)) {
+    if (isCommentNotifictionType(type) || isMessageWallPost(type) || isMessageWallThread(type)) {
         return 'comment-small';
     }
 
@@ -34,6 +37,11 @@ function getIconName(type) {
     if (isArticleCommentAtMention(type) || isArticleCommentReplyAtMention(type)) {
         return 'mention-small';
     }
+
+    if (isTalkPageMessage(type)) {
+        return 'bubble-small';
+    }
+
 
     return 'heart-small';
 }

--- a/source/components/GlobalNavigation/components/Notifications/MarkAsReadIcon.spec.js
+++ b/source/components/GlobalNavigation/components/Notifications/MarkAsReadIcon.spec.js
@@ -63,6 +63,18 @@ test('MarkAsReadIcon renders correctly for article-comment-reply-at-mention', ()
     expect(renderComponent({ model: { type: notificationTypes.articleCommentReplyAtMention } })).toMatchSnapshot();
 });
 
+test('MarkAsReadIcon renders correctly for talk-page-message', () => {
+    expect(renderComponent({ model: { type: notificationTypes.talkPageMessage } })).toMatchSnapshot();
+});
+
+test('MarkAsReadIcon renders correctly for message-wall-thread', () => {
+    expect(renderComponent({ model: { type: notificationTypes.messageWallThread } })).toMatchSnapshot();
+});
+
+test('MarkAsReadIcon renders correctly for message-wall-post', () => {
+    expect(renderComponent({ model: { type: notificationTypes.messageWallPost } })).toMatchSnapshot();
+});
+
 test('MarkAsReadIcon calls track and markAsRead on click when isUnread is true', () => {
     const markAsReadMock = jest.fn();
     const trackMock = jest.fn();

--- a/source/components/GlobalNavigation/components/Notifications/NotificationsDataProvider.js
+++ b/source/components/GlobalNavigation/components/Notifications/NotificationsDataProvider.js
@@ -74,7 +74,7 @@ class NotificationsDataProvider extends React.Component {
             return;
         }
 
-        this.loadPage(nextPage);
+        this.loadPage(`${nextPage}&${NotificationsApi.getContentTypesQueryParams()}`);
     }
 
     loadPage(pageLink) {

--- a/source/components/GlobalNavigation/components/Notifications/NotificationsDataProvider.spec.js
+++ b/source/components/GlobalNavigation/components/Notifications/NotificationsDataProvider.spec.js
@@ -161,7 +161,7 @@ describe('loadNextPage', () => {
 
         instance.loadNextPage();
 
-        expect(loadPageMock).toBeCalledWith(nextPageMock);
+        expect(loadPageMock).toBeCalledWith(expect.any(String));
     });
 
     test('does not call loadPage when nextPage in state is null', () => {

--- a/source/components/GlobalNavigation/components/Notifications/__snapshots__/CardText.spec.js.snap
+++ b/source/components/GlobalNavigation/components/Notifications/__snapshots__/CardText.spec.js.snap
@@ -250,6 +250,90 @@ exports[`Discussion reply upvote CardText renders correctly for discussion reply
 </p>
 `;
 
+exports[`Wall post CardText renders correctly for multiple replies on others wall 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-wall-reply-multiple-users{"postTitle":"
+  <b>
+    Article &lt;b&gt;Title&lt;/b&gt;
+  </b>
+  ","wallOwner":"TestOther","number":"2","firstUser":"Test","secondUser":"TestOther"}
+</p>
+`;
+
+exports[`Wall post CardText renders correctly for multiple replies on own wall 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-own-wall-reply-multiple-users{"postTitle":"
+  <b>
+    Article &lt;b&gt;Title&lt;/b&gt;
+  </b>
+  ","wallOwner":"Test","number":"2","user":"notifications-anon-user"}
+</p>
+`;
+
+exports[`Wall post CardText renders correctly for reply to own message when multiple actors 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-wall-reply-multiple-users-own-message{"postTitle":"
+  <b>
+    Article &lt;b&gt;Title&lt;/b&gt;
+  </b>
+  ","wallOwner":"TestOther","number":"2","firstUser":"Test"}
+</p>
+`;
+
+exports[`Wall post CardText renders correctly for single reply on others wall 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-wall-reply{"postTitle":"
+  <b>
+    Article &lt;b&gt;Title&lt;/b&gt;
+  </b>
+  ","wallOwner":"TestOther","firstUser":"Test","secondUser":"TestOther"}
+</p>
+`;
+
+exports[`Wall post CardText renders correctly for single reply on own wall 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-own-wall-reply{"postTitle":"
+  <b>
+    Article &lt;b&gt;Title&lt;/b&gt;
+  </b>
+  ","wallOwner":"Test","user":"Test"}
+</p>
+`;
+
+exports[`Wall post CardText renders correctly for single reply to own message 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-wall-reply-own-message{"postTitle":"
+  <b>
+    Article &lt;b&gt;Title&lt;/b&gt;
+  </b>
+  ","wallOwner":"TestOther","user":"Test"}
+</p>
+`;
+
+exports[`Wall post CardText renders correctly when metadata is missing 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-own-wall-reply{"postTitle":"
+  <b>
+    Article &lt;b&gt;Title&lt;/b&gt;
+  </b>
+  ","wallOwner":"Test","user":"notifications-anon-user"}
+</p>
+`;
+
 exports[`Wall thread CardText renders correctly for others wall 1`] = `
 <p
   class="wds-notification-card__text"

--- a/source/components/GlobalNavigation/components/Notifications/__snapshots__/CardText.spec.js.snap
+++ b/source/components/GlobalNavigation/components/Notifications/__snapshots__/CardText.spec.js.snap
@@ -249,3 +249,39 @@ exports[`Discussion reply upvote CardText renders correctly for discussion reply
   ","number":2}
 </p>
 `;
+
+exports[`Wall thread CardText renders correctly for others wall 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-wall-post{"firstUser":"Test2","postTitle":"
+  <b>
+    Article &lt;b&gt;Title&lt;/b&gt;
+  </b>
+  ","wallOwner":"Test2"}
+</p>
+`;
+
+exports[`Wall thread CardText renders correctly for own wall 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-own-wall-post{"user":"Test","postTitle":"
+  <b>
+    Article &lt;b&gt;Title&lt;/b&gt;
+  </b>
+  ","wallOwner":"Test"}
+</p>
+`;
+
+exports[`Wall thread CardText renders correctly when metadata is missing 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-own-wall-post{"user":"notifications-anon-user","postTitle":"
+  <b>
+    Article &lt;b&gt;Title&lt;/b&gt;
+  </b>
+  ","wallOwner":"Test"}
+</p>
+`;

--- a/source/components/GlobalNavigation/components/Notifications/__snapshots__/CardText.spec.js.snap
+++ b/source/components/GlobalNavigation/components/Notifications/__snapshots__/CardText.spec.js.snap
@@ -342,6 +342,18 @@ exports[`Wall post CardText renders correctly when metadata is missing 1`] = `
 </p>
 `;
 
+exports[`Wall post CardText renders correctly when wall URL is invalid 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-wall-reply{"postTitle":"
+  <b>
+    Article &lt;b&gt;Title&lt;/b&gt;
+  </b>
+  ","wallOwner":null,"firstUser":"notifications-anon-user","secondUser":"Test"}
+</p>
+`;
+
 exports[`Wall thread CardText renders correctly for others wall 1`] = `
 <p
   class="wds-notification-card__text"

--- a/source/components/GlobalNavigation/components/Notifications/__snapshots__/CardText.spec.js.snap
+++ b/source/components/GlobalNavigation/components/Notifications/__snapshots__/CardText.spec.js.snap
@@ -250,6 +250,14 @@ exports[`Discussion reply upvote CardText renders correctly for discussion reply
 </p>
 `;
 
+exports[`Talk page CardText renders correctly 1`] = `
+<p
+  class="wds-notification-card__text"
+>
+  notifications-talk-page-message{"user":"Test"}
+</p>
+`;
+
 exports[`Wall post CardText renders correctly for multiple replies on others wall 1`] = `
 <p
   class="wds-notification-card__text"

--- a/source/components/GlobalNavigation/components/Notifications/__snapshots__/MarkAsReadIcon.spec.js.snap
+++ b/source/components/GlobalNavigation/components/Notifications/__snapshots__/MarkAsReadIcon.spec.js.snap
@@ -70,6 +70,34 @@ exports[`MarkAsReadIcon renders correctly for discussion-reply 1`] = `
 </div>
 `;
 
+exports[`MarkAsReadIcon renders correctly for message-wall-post 1`] = `
+<div
+  className="wds-notification-card__icon-wrapper"
+  role="presentation"
+>
+  <Icon
+    className=""
+    name="comment-small"
+    small={false}
+    tiny={false}
+  />
+</div>
+`;
+
+exports[`MarkAsReadIcon renders correctly for message-wall-thread 1`] = `
+<div
+  className="wds-notification-card__icon-wrapper"
+  role="presentation"
+>
+  <Icon
+    className=""
+    name="comment-small"
+    small={false}
+    tiny={false}
+  />
+</div>
+`;
+
 exports[`MarkAsReadIcon renders correctly for other types 1`] = `
 <div
   className="wds-notification-card__icon-wrapper"
@@ -78,6 +106,20 @@ exports[`MarkAsReadIcon renders correctly for other types 1`] = `
   <Icon
     className=""
     name="heart-small"
+    small={false}
+    tiny={false}
+  />
+</div>
+`;
+
+exports[`MarkAsReadIcon renders correctly for talk-page-message 1`] = `
+<div
+  className="wds-notification-card__icon-wrapper"
+  role="presentation"
+>
+  <Icon
+    className=""
+    name="bubble-small"
     small={false}
     tiny={false}
   />

--- a/source/components/GlobalNavigation/models/Notification.js
+++ b/source/components/GlobalNavigation/models/Notification.js
@@ -25,6 +25,7 @@ function mapData(notificationData) {
         snippet: get(notificationData, 'refersTo.snippet'),
         uri: get(notificationData, 'refersTo.uri'),
         refersToAuthorId: get(notificationData, 'refersTo.createdBy'),
+        refersToAuthorName: get(notificationData, 'refersTo.createdByName'),
         latestEventUri: get(notificationData, 'events.latestEvent.uri'),
         timestamp: convertToTimestamp(get(notificationData, 'events.latestEvent.when')),
         communityName: get(notificationData, 'community.name'),

--- a/source/components/GlobalNavigation/models/Notification.js
+++ b/source/components/GlobalNavigation/models/Notification.js
@@ -64,6 +64,12 @@ function getNotificationType(apiData) {
             return notificationTypes.articleCommentAtMention;
         case 'article-comment-reply-at-mention-notification':
             return notificationTypes.articleCommentReplyAtMention;
+        case 'talk-page-notification':
+            return notificationTypes.talkPageMessage;
+        case 'message-wall-post-notification':
+            return notificationTypes.messageWallThread;
+        case 'message-wall-reply-notification':
+            return notificationTypes.messageWallPost;
         default:
             return null;
     }

--- a/source/components/GlobalNavigation/models/Notification.js
+++ b/source/components/GlobalNavigation/models/Notification.js
@@ -33,6 +33,7 @@ function mapData(notificationData) {
         totalUniqueActors: get(notificationData, 'events.totalUniqueActors'),
         latestActors: createActors(get(notificationData, 'events.latestActors')),
         type: getNotificationType(notificationData),
+        metadata: getMetadata(notificationData),
     };
 }
 
@@ -73,6 +74,11 @@ function getNotificationType(apiData) {
         default:
             return null;
     }
+}
+
+function getMetadata(notificationData) {
+    const metadata = get(notificationData, 'metadata');
+    return metadata ? JSON.parse(metadata) : null;
 }
 
 class Notification {

--- a/source/components/GlobalNavigation/models/Notification.spec.js
+++ b/source/components/GlobalNavigation/models/Notification.spec.js
@@ -12,6 +12,7 @@ const getNotification = config => merge({}, {
     refersTo: {
         uri: 'http://xkxd.fandom.com/d/p/3100000000000001095/r/3086787452863005630',
         createdBy: '33027931',
+        createdByName: 'Test',
         type: 'discussion-post',
         snippet: 'gimme',
     },
@@ -44,12 +45,14 @@ const getExpected = config => merge({}, {
     snippet: 'gimme',
     uri: 'http://xkxd.fandom.com/d/p/3100000000000001095/r/3086787452863005630',
     latestEventUri: 'http://xkxd.fandom.com/d/p/3100000000000001095/r/3086787452863005630#12315543',
+    metadata: null,
     timestamp: 1551422928,
     communityName: 'Xkxd Wiki',
     communityId: '1619010',
     isUnread: true,
     totalUniqueActors: 1,
     refersToAuthorId: '33027931',
+    refersToAuthorName: 'Test',
     latestActors: [{
         id: '12315543',
         name: 'QATestsStaff2',

--- a/source/components/GlobalNavigation/models/Notification.spec.js
+++ b/source/components/GlobalNavigation/models/Notification.spec.js
@@ -38,6 +38,7 @@ const getNotification = config => merge({}, {
         },
     },
     read: false,
+    metadata: '{}',
 }, config);
 
 const getExpected = config => merge({}, {
@@ -45,7 +46,7 @@ const getExpected = config => merge({}, {
     snippet: 'gimme',
     uri: 'http://xkxd.fandom.com/d/p/3100000000000001095/r/3086787452863005630',
     latestEventUri: 'http://xkxd.fandom.com/d/p/3100000000000001095/r/3086787452863005630#12315543',
-    metadata: null,
+    metadata: {},
     timestamp: 1551422928,
     communityName: 'Xkxd Wiki',
     communityId: '1619010',
@@ -113,6 +114,26 @@ const testCases = [
         name: 'article-comment-reply-at-mention notification',
         given: getNotification({ type: 'article-comment-reply-at-mention-notification' }),
         expected: getExpected({ type: notificationTypes.articleCommentReplyAtMention }),
+    },
+    {
+        name: 'message-wall-thread notification',
+        given: getNotification({ type: 'message-wall-post-notification' }),
+        expected: getExpected({ type: notificationTypes.messageWallThread }),
+    },
+    {
+        name: 'message-wall-post notification',
+        given: getNotification({ type: 'message-wall-reply-notification' }),
+        expected: getExpected({ type: notificationTypes.messageWallPost }),
+    },
+    {
+        name: 'talk-page-message notification',
+        given: getNotification({ type: 'talk-page-notification' }),
+        expected: getExpected({ type: notificationTypes.talkPageMessage }),
+    },
+    {
+        name: 'empty metadata',
+        given: getNotification({ metadata: null }),
+        expected: getExpected({ metadata: null }),
     },
 ];
 

--- a/source/components/GlobalNavigation/models/notificationTypes.js
+++ b/source/components/GlobalNavigation/models/notificationTypes.js
@@ -5,9 +5,12 @@ export const notificationTypes = {
     announcement: 'announcement',
     postAtMention: 'post-at-mention',
     threadAtMention: 'thread-at-mention',
+    messageWallThread: 'message-wall-thread',
+    messageWallPost: 'message-wall-post',
     articleCommentReply: 'article-comment-reply',
     articleCommentAtMention: 'article-comment-at-mention',
     articleCommentReplyAtMention: 'article-comment-reply-at-mention',
+    talkPageMessage: 'talk-page-message',
 };
 
 export const isDiscussionReply = type => type === notificationTypes.discussionReply;
@@ -16,6 +19,9 @@ export const isDiscussionPostUpvote = type => type === notificationTypes.discuss
 export const isAnnouncement = type => type === notificationTypes.announcement;
 export const isPostAtMention = type => type === notificationTypes.postAtMention;
 export const isThreadAtMention = type => type === notificationTypes.threadAtMention;
+export const isMessageWallThread = type => type === notificationTypes.messageWallThread;
+export const isMessageWallPost = type => type === notificationTypes.messageWallPost;
 export const isArticleCommentReply = type => type === notificationTypes.articleCommentReply;
 export const isArticleCommentAtMention = type => type === notificationTypes.articleCommentAtMention;
 export const isArticleCommentReplyAtMention = type => type === notificationTypes.articleCommentReplyAtMention;
+export const isTalkPageMessage = type => type === notificationTypes.talkPageMessage;

--- a/source/components/GlobalNavigation/utils/NotificationsApi.js
+++ b/source/components/GlobalNavigation/utils/NotificationsApi.js
@@ -8,9 +8,12 @@ const supportedContentTypes = [
     'announcement-target',
     'post-at-mention',
     'thread-at-mention',
+    'message-wall-thread',
+    'message-wall-post',
     'article-comment-reply',
     'article-comment-at-mention',
     'article-comment-reply-at-mention',
+    'talk-page-message',
 ];
 
 const defaultOptions = {


### PR DESCRIPTION
### Links
- https://wikia-inc.atlassian.net/browse/SITE-217

### Description

**Problem 1**: Global nav in react-common uses its own definition of notification types that should be fetched. It was missing some entries comparing to UCP implementation, namely ones related to wall events. Therefore you couldn’t see all the notifications while on the discussion page.

**Problem 2**: Global nav implementation in react-common wouldn’t attach notification types at all when lazy loading next batches of notifications as a user scrolls down the notif dropdown. This resulted in an empty response from the on-site-notifications service. Therefore you were able to see only the first 10 notifications that were fetched in the initial load.

**Fix**: Add missing content types and make sure to include content types when lazy loading the next pages of notifications.

Changes mirrored in `fandom-frontend` →  https://github.com/Wikia/fandom-frontend/pull/40